### PR TITLE
Add root route for health check (GET /)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,10 @@ app.use(morgan('tiny'));
 app.use(cors());
 app.use(express.json());
 
+app.get('/', (_req: Request, res: Response) => {
+  res.status(200).send('Backend is alive!');
+});
+
 app.use('/api/:language', routes);
 
 app.use((req, res) => {


### PR DESCRIPTION
This PR adds a simple root route (GET /) that returns a JSON message confirming that the server is running. This is useful for uptime monitoring services like UptimeRobot to prevent the backend from going to sleep on Render.com.